### PR TITLE
Proposed changes to adding salt to documents

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ web3
 pyyaml
 requests
 dtweb
-uuid


### PR DESCRIPTION
Instead of generating random salt for each document, the hash of previous twin's hash-info.json could be used. If no hash-info.json exists, a random hex string is used.
Otherwise, the implementation is the same as before + some tidying up code to functions.

This way we can add extra salt by simply modifying the hash-info.json of the current twin.

Thoughts?